### PR TITLE
Fix side_sculpting dynamic call and guard Customizer variable

### DIFF
--- a/src/functions.scad
+++ b/src/functions.scad
@@ -26,7 +26,18 @@ function cherry_cross(slop, extra_vertical = 0) = [
 
 // TODO add side_sculpting
 function key_width_at_progress(progress = 0) = $bottom_key_width + ($unit * ($key_length - 1)) - $width_difference;
-function key_height_at_progress(progress = 0) = $bottom_key_height + ($unit * ($key_height - 1)) - $height_difference + $side_sculpting(progress);
+// NOTE:
+// OpenSCAD special variables (prefixed with `$`) cannot be invoked as
+// functions directly.  The previous implementation attempted to call the
+// dynamically-scoped variable `$side_sculpting` as a function which
+// triggered warnings such as "Can't call function on dynamically scoped
+// variable" and produced `undef` values downstream.  To preserve the
+// ability to override `$side_sculpting` from key profile files while
+// avoiding these warnings, copy the variable into a locally scoped
+// identifier before invoking it.
+function key_height_at_progress(progress = 0) =
+  let(side_fn = $side_sculpting)
+    $bottom_key_height + ($unit * ($key_height - 1)) - $height_difference + side_fn(progress);
 
 // actual mm key width and height
 function total_key_width(delta = 0) = $bottom_key_width + $unit * ($key_length - 1) - delta;

--- a/src/key.scad
+++ b/src/key.scad
@@ -266,6 +266,10 @@ module example_key(){
   key();
 }
 
-if (!$using_customizer) {
+// `$using_customizer` is defined when the file is included from the
+// Customizer interface.  When running the file directly the variable is
+// undefined which previously triggered a warning.  Check with `is_undef()`
+// so the example key renders cleanly in both scenarios.
+if (is_undef($using_customizer) || !$using_customizer) {
   example_key();
 }


### PR DESCRIPTION
## Summary
- avoid calling `$side_sculpting` directly by invoking a locally scoped function
- guard example key generation when `$using_customizer` is undefined

## Testing
- `npm test` (fails: no tests specified)
- `openscad -o /tmp/key.csg src/key.scad`


------
https://chatgpt.com/codex/tasks/task_e_68a8f4e59484832090615cd286cd7602