### PR TITLE
fix: allow overriding settings in key profiles

### DIFF
--- a/src/key_profiles/asa.scad
+++ b/src/key_profiles/asa.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 
 module asa_row(row=3, column = 0) {
 $key_shape_type = "sculpted_square";

--- a/src/key_profiles/cherry.scad
+++ b/src/key_profiles/cherry.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 
 // based off GMK keycap set
 

--- a/src/key_profiles/dcs.scad
+++ b/src/key_profiles/dcs.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 
 module dcs_row(row=3, column=0) {
   $bottom_key_width = 18.16;

--- a/src/key_profiles/dsa.scad
+++ b/src/key_profiles/dsa.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 
 module dsa_row(row=3, column = 0) {
   $key_shape_type = "sculpted_square";

--- a/src/key_profiles/dss.scad
+++ b/src/key_profiles/dss.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 
 module dss_row(n=3, column=0) {
   $key_shape_type = "sculpted_square";

--- a/src/key_profiles/g20.scad
+++ b/src/key_profiles/g20.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 
 module g20_row(row=3, column = 0) {
   $bottom_key_width = 18.16;

--- a/src/key_profiles/grid.scad
+++ b/src/key_profiles/grid.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 
 module grid_row(row=3, column = 0) {
   $bottom_key_width = 18.16;

--- a/src/key_profiles/hipro.scad
+++ b/src/key_profiles/hipro.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 
 module hipro_row(row=3, column=0) {
   $key_shape_type = "sculpted_square";

--- a/src/key_profiles/mt3.scad
+++ b/src/key_profiles/mt3.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 
 // This is an imperfect attempt to clone the MT3 profile
 module mt3_row(row=3, column=0, deep_dish=false) {

--- a/src/key_profiles/oem.scad
+++ b/src/key_profiles/oem.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 
 module oem_row(row=3, column = 0) {
   $bottom_key_width = 18.05;

--- a/src/key_profiles/regular_polygon.scad
+++ b/src/key_profiles/regular_polygon.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 include <../constants.scad>
 // Regular polygon shapes CIRCUMSCRIBE the sphere of diameter $bottom_key_width
 // This is to make tiling them easier, like in the case of hexagonal keycaps etc

--- a/src/key_profiles/sa.scad
+++ b/src/key_profiles/sa.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 
 module sa_row(n=3, column=0) {
   $key_shape_type = "sculpted_square";

--- a/src/key_profiles/typewriter.scad
+++ b/src/key_profiles/typewriter.scad
@@ -1,5 +1,4 @@
 use <../functions.scad>
-include <../settings.scad>
 include <../constants.scad>
 // Regular polygon shapes CIRCUMSCRIBE the sphere of diameter $bottom_key_width
 // This is to make tiling them easier, like in the case of hexagonal keycaps etc


### PR DESCRIPTION
## Summary
- remove direct inclusion of settings from key profile modules so user-defined overrides work again

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f6eac81c8320ba332436a90ac68e