### PR TITLE
feat: align halves with gap

### DIFF
--- a/uhk80.scad
+++ b/uhk80.scad
@@ -185,9 +185,14 @@ module uhk80_half(side="both", rows=undef, gap=0.5) {
   if (side == "left" || side == "both")
     _uhk80_render_half(uhk80_left_rows, rows);
   if (side == "right" || side == "both") {
+    selected_rows = rows == undef
+        ? uhk80_right_rows
+        : [for (i = [0 : len(uhk80_right_rows) - 1])
+             if (rows == i + 1 || (is_list(rows) && len([for (r = rows) if (r == i + 1) r]) > 0))
+               uhk80_right_rows[i]];
     right_end = side == "both"
         ? 17
-        : max([for (row = uhk80_right_rows) sum([for (k = row) k[1]])]);
+        : max([for (row = selected_rows) sum([for (k = row) k[1]])]);
     translate_u(side == "both" ? gap : 0) {
       _uhk80_render_half(
         uhk80_right_rows,
@@ -198,7 +203,7 @@ module uhk80_half(side="both", rows=undef, gap=0.5) {
 
       // Arrow up key sits above the arrow cluster; render when row 3 is included
       if (rows == undef || rows == 3 || (is_list(rows) && len([for (r = rows) if (r == 3) r]) > 0))
-        translate_u(right_end - 1, -2)
+        translate_u(right_end - 2, -2)
           _uhk80_key(3, 1) legend("\u2191") key();
     }
   }

--- a/uhk80.scad
+++ b/uhk80.scad
@@ -95,123 +95,138 @@ module R5U2_75() { _uhk80_key(5,2.75) children(); }
 module R5U6_25() { _uhk80_key(5,6.25) children(); }
 
 // Layout data for UHK80 halves
-// Each entry: [row (R value), unit width (U value), legend, x position, y position, font size]
-uhk80_left_layout = [
-  [1, 1, "Esc", 0, 0, 4],
-  [1, 1, "F1", 1, 0, 3],
-  [1, 1, "F2", 2, 0, 3],
-  [1, 1, "F3", 3, 0, 3],
-  [1, 1, "F4", 4, 0, 3],
-  [1, 1, "F5", 5, 0, 3],
-  [1, 1, "F6", 6, 0, 3],
+// Row numbers start at the top: row 1 is the F1/F7 row for left/right halves
 
-  [2, 1, "1", 0, -1, 4],
-  [2, 1, "2", 1, -1, 4],
-  [2, 1, "3", 2, -1, 4],
-  [2, 1, "4", 3, -1, 4],
-  [2, 1, "5", 4, -1, 4],
-  [2, 1, "6", 5, -1, 4],
-
-  [3, 1.5, "Tab", 0, -2, 4],
-  [3, 1, "Q", 1.5, -2, 4],
-  [3, 1, "W", 2.5, -2, 4],
-  [3, 1, "E", 3.5, -2, 4],
-  [3, 1, "R", 4.5, -2, 4],
-  [3, 1, "T", 5.5, -2, 4],
-
-  [4, 1.75, "Caps", 0, -3, 4],
-  [4, 1, "A", 1.75, -3, 4],
-  [4, 1, "S", 2.75, -3, 4],
-  [4, 1, "D", 3.75, -3, 4],
-  [4, 1, "F", 4.75, -3, 4],
-  [4, 1, "G", 5.75, -3, 4],
-
-  [5, 1.25, "Shift", 0, -4, 4],
-  [5, 1, "Z", 1.25, -4, 4],
-  [5, 1, "X", 2.25, -4, 4],
-  [5, 1, "C", 3.25, -4, 4],
-  [5, 1, "V", 4.25, -4, 4],
-  [5, 1, "B", 5.25, -4, 4],
-
-  [5, 1.25, "Ctrl", 0, -5, 4],
-  [5, 1.25, "Super", 1.25, -5, 4],
-  [5, 1.25, "Alt", 2.5, -5, 4],
-  [5, 2.25, "Space", 3.75, -5, 4]
+// Left half rows: [ [row, width, legend, (optional) font size], ... ]
+uhk80_left_rows = [
+  // Row 1
+  [
+    [1, 1, "Esc"],
+    [1, 1, "F1", 3],
+    [1, 1, "F2", 3],
+    [1, 1, "F3", 3],
+    [1, 1, "F4", 3],
+    [1, 1, "F5", 3],
+    [1, 1, "F6", 3]
+  ],
+  // Row 2
+  [
+    [2, 1, "1"], [2, 1, "2"], [2, 1, "3"],
+    [2, 1, "4"], [2, 1, "5"], [2, 1, "6"]
+  ],
+  // Row 3
+  [
+    [3, 1.5, "Tab"], [3, 1, "Q"], [3, 1, "W"],
+    [3, 1, "E"], [3, 1, "R"], [3, 1, "T"]
+  ],
+  // Row 4
+  [
+    [4, 1.75, "Caps"], [4, 1, "A"], [4, 1, "S"],
+    [4, 1, "D"], [4, 1, "F"], [4, 1, "G"]
+  ],
+  // Row 5
+  [
+    [5, 1.25, "Shift"], [5, 1, "Z"], [5, 1, "X"],
+    [5, 1, "C"], [5, 1, "V"], [5, 1, "B"]
+  ],
+  // Row 6 (bottom)
+  [
+    [5, 1.25, "Ctrl"], [5, 1.25, "Super"],
+    [5, 1.25, "Alt"], [5, 2.25, "Space"]
+  ]
 ];
 
-uhk80_right_layout = [
-  [1, 1, "F7", 7, 0, 3],
-  [1, 1, "F8", 8, 0, 3],
-  [1, 1, "F9", 9, 0, 3],
-  [1, 1, "F10", 10, 0, 3],
-  [1, 1, "F11", 11, 0, 3],
-  [1, 1, "F12", 12, 0, 3],
-  [1, 1.5, "PrtSc", 13, 0, 3],
-  [1, 1, "Scroll", 14.5, 0, 3],
-  [1, 1, "Pause", 15.5, 0, 3],
-
-  [2, 1, "7", 7, -1, 4],
-  [2, 1, "8", 8, -1, 4],
-  [2, 1, "9", 9, -1, 4],
-  [2, 1, "0", 10, -1, 4],
-  [2, 1, "-", 11, -1, 4],
-  [2, 1, "=", 12, -1, 4],
-  [1, 1.5, "Backspace", 13, -1, 4],
-  [1, 1, "Insert", 15, -1, 4],
-  [1, 1, "Home", 16, -1, 4],
-  [1, 1, "PgUp", 17, -1, 4],
-
-  [3, 1, "Y", 7, -2, 4],
-  [3, 1, "U", 8, -2, 4],
-  [3, 1, "I", 9, -2, 4],
-  [3, 1, "O", 10, -2, 4],
-  [3, 1, "P", 11, -2, 4],
-  [3, 1, "[", 12, -2, 4],
-  [3, 1, "]", 13, -2, 4],
-  [3, 1, "\\", 14, -2, 4],
-  [2, 1, "Delete", 15, -2, 4],
-  [2, 1, "End", 16, -2, 4],
-  [2, 1, "PgDn", 17, -2, 4],
-  [3, 1, "\u2191", 16, -2, 4],
-
-  [4, 1, "H", 7, -3, 4],
-  [4, 1, "J", 8, -3, 4],
-  [4, 1, "K", 9, -3, 4],
-  [4, 1, "L", 10, -3, 4],
-  [4, 1, ";", 11, -3, 4],
-  [4, 1, "'", 12, -3, 4],
-  [4, 2.25, "Enter", 13, -3, 4],
-  [4, 1, "\u2190", 15, -3, 4],
-  [4, 1, "\u2193", 16, -3, 4],
-  [4, 1, "\u2192", 17, -3, 4],
-
-  [5, 1, "N", 7, -4, 4],
-  [5, 1, "M", 8, -4, 4],
-  [5, 1, ",", 9, -4, 4],
-  [5, 1, ".", 10, -4, 4],
-  [5, 1, "/", 11, -4, 4],
-  [5, 2.75, "Shift", 12, -4, 4],
-
-  [5, 2.25, "Space", 7, -5, 4],
-  [5, 1.25, "Alt", 9.25, -5, 4],
-  [5, 1.25, "Fn", 10.5, -5, 4],
-  [5, 1.25, "Ctrl", 11.75, -5, 4]
+// Right half rows
+uhk80_right_rows = [
+  // Row 1
+  [
+    [1, 1, "F7", 3], [1, 1, "F8", 3], [1, 1, "F9", 3],
+    [1, 1, "F10", 3], [1, 1, "F11", 3], [1, 1, "F12", 3],
+    [0, 1.5],
+    [1, 1.5, "PrtSc", 3], [1, 1, "Scroll", 3], [1, 1, "Pause", 3]
+  ],
+  // Row 2
+  [
+    [2, 1, "7"], [2, 1, "8"], [2, 1, "9"],
+    [2, 1, "0"], [2, 1, "-"], [2, 1, "="],
+    [1, 1.5, "Backspace"], [0, 0.5],
+    [1, 1, "Insert"], [1, 1, "Home"], [1, 1, "PgUp"]
+  ],
+  // Row 3
+  [
+    [3, 1, "Y"], [3, 1, "U"], [3, 1, "I"],
+    [3, 1, "O"], [3, 1, "P"], [3, 1, "["],
+    [3, 1, "]"], [3, 1, "\\"],
+    [2, 1, "Delete"], [2, 1, "End"], [2, 1, "PgDn"]
+  ],
+  // Row 4
+  [
+    [4, 1, "H"], [4, 1, "J"], [4, 1, "K"],
+    [4, 1, "L"], [4, 1, ";"], [4, 1, "'"],
+    [4, 2.25, "Enter"], [0, 0.75],
+    [4, 1, "\u2190"], [4, 1, "\u2193"], [4, 1, "\u2192"]
+  ],
+  // Row 5
+  [
+    [5, 1, "N"], [5, 1, "M"], [5, 1, ","],
+    [5, 1, "."], [5, 1, "/"], [5, 2.75, "Shift"]
+  ],
+  // Row 6 (bottom)
+  [
+    [5, 2.25, "Space"], [5, 1.25, "Alt"],
+    [5, 1.25, "Fn"], [5, 1.25, "Ctrl"]
+  ]
 ];
 
 // Render selected half of the UHK80 layout
 // side can be "left", "right", or "both"
-module uhk80_half(side="both") {
+// rows can be an integer or vector of integers to render only specific rows
+module uhk80_half(side="both", rows=undef, gap=0.5) {
   if (side == "left" || side == "both")
-    _uhk80_render_half(uhk80_left_layout);
+    _uhk80_render_half(uhk80_left_rows, rows);
   if (side == "right" || side == "both")
-    _uhk80_render_half(uhk80_right_layout);
+    translate_u(side == "both" ? gap : 0) {
+      _uhk80_render_half(
+        uhk80_right_rows,
+        rows,
+        end_column=17,
+        align_right=true
+      );
+
+      // Arrow up key sits above the arrow cluster; render when row 3 is included
+      if (rows == undef || rows == 3 || (is_list(rows) && len([for (r = rows) if (r == 3) r]) > 0))
+        translate_u(16, -2)
+          _uhk80_key(3, 1) legend("\u2191") key();
+    }
 }
 
-// Internal: render a list of keys using _uhk80_key
-module _uhk80_render_half(keys) {
-  for (k = keys)
-    translate_u(k[3], k[4])
-      _uhk80_key(k[0], k[1]) legend(k[2], size=k[5]) key();
+// Internal: render rows of keys using _uhk80_key
+module _uhk80_render_half(rows_data, rows=undef, end_column=undef, align_right=false, starts=0) {
+  for (i = [0 : len(rows_data) - 1]) {
+    row_number = i + 1;
+    if (rows == undef || row_number == rows || (is_list(rows) && len([for (r = rows) if (r == row_number) r]) > 0)) {
+      row = rows_data[i];
+      align = is_list(align_right)
+          ? (i < len(align_right) ? align_right[i] : false)
+          : align_right;
+      start = is_list(starts)
+          ? (i < len(starts) ? starts[i] : 0)
+          : starts;
+      total_width = sum([for (k = row) k[1]]);
+      last_width = row[len(row) - 1][1];
+      x = align && end_column != undef
+          ? end_column - (total_width - last_width)
+          : start;
+      for (key = row) {
+        width = key[1];
+        if (len(key) > 2)
+          translate_u(x, -i)
+            _uhk80_key(key[0], width) legend(key[2], size = len(key) > 3 ? key[3] : 4) key();
+        x = x + width;
+      }
+    }
+  }
 }
 
-uhk80_half("right");
+// Example: render both halves
+uhk80_half("both");

--- a/uhk80.scad
+++ b/uhk80.scad
@@ -201,8 +201,8 @@ module uhk80_half(side="both", rows=undef, gap=0.5) {
         align_right=true
       );
 
-      // Arrow up key sits above the arrow cluster; render when row 3 is included
-      if (rows == undef || rows == 3 || (is_list(rows) && len([for (r = rows) if (r == 3) r]) > 0))
+      // Arrow up key sits above the arrow cluster; render when row 4 is included
+      if (rows == undef || rows == 4 || (is_list(rows) && len([for (r = rows) if (r == 4) r]) > 0))
         translate_u(right_end - 2, -2)
           _uhk80_key(3, 1) legend("\u2191") key();
     }
@@ -239,5 +239,5 @@ module _uhk80_render_half(rows_data, rows=undef, end_column=undef, align_right=f
   }
 }
 
-// Example: render both halves
-uhk80_half("both");
+// Example: render the right half
+uhk80_half("right");

--- a/uhk80.scad
+++ b/uhk80.scad
@@ -183,14 +183,19 @@ uhk80_right_rows = [
 // offset: horizontal shift applied before placing the first key
 module uhk80_right_row(row = 1, offset = 0) {
   row_data = uhk80_right_rows[row - 1];
-  x = offset;
-  for (key = row_data) {
+  _uhk80_render_right_row(row_data, row, offset);
+}
+
+// Recursively render each key in a right-half row without mutating state.
+module _uhk80_render_right_row(row_data, row, x) {
+  if (len(row_data) > 0) {
+    key = row_data[0];
     width = key[1];
     if (len(key) > 2)
       translate_u(x, -(row - 1))
         _uhk80_key(key[0], width)
           legend(key[2], size = len(key) > 3 ? key[3] : 4) key();
-    x = x + width;
+    _uhk80_render_right_row(row_data[1:len(row_data)-1], row, x + width);
   }
 }
 

--- a/uhk80.scad
+++ b/uhk80.scad
@@ -1,203 +1,112 @@
-// Convenience modules for Ultimate Hacking Keyboard 80 keycaps
-// Usage: include this file in keys.scad and reference modules like
-// R1U1() legend("text") key();
-// Decimal unit sizes use underscores, e.g. R2U1_25 for a 1.25u key.
-
 include <./includes.scad>;
 
-// Defaults for UHK80 keys
-$font_size = 4; // Font size for legends
-$outset_legends = true;
-$support_type = "disable";
-$stem_support_type = "disable";
-$stabilizer_type = "disable";
 
-// Default vertical depth multiplier for UHK80 keys (50% taller than standard)
-$uhk80_depth_scale = 1.5;
-
-// Default top dish depth controlling curvature (higher values curve more)
-$uhk80_dish_depth = 0.75;
-
-// Additional forward tilt in degrees; negative tilts top downward more
-$uhk80_tilt_adjust = -2;
-
-// Internal helper for applying row profile, unit width, and depth scaling
-module _uhk80_key(row, u) {
-  let($dish_depth_override = $uhk80_dish_depth)
-    dcs_row(row) u(u) {
-      let(
-        extra_depth = $total_depth * ($uhk80_depth_scale - 1),
-        $stem_inset = $stem_inset + extra_depth,
-        $total_depth = $total_depth * $uhk80_depth_scale,
-        $top_tilt = $top_tilt + $uhk80_tilt_adjust
-      ) children();
-    }
-}
-
-// Row 1
-module R1U1() { _uhk80_key(1,1) children(); }
-module R1U1_25() { _uhk80_key(1,1.25) children(); }
-module R1U1_5() { _uhk80_key(1,1.5) children(); }
-module R1U1_75() { _uhk80_key(1,1.75) children(); }
-module R1U2() { _uhk80_key(1,2) children(); }
-module R1U2_25() { _uhk80_key(1,2.25) children(); }
-module R1U2_75() { _uhk80_key(1,2.75) children(); }
-module R1U6_25() { _uhk80_key(1,6.25) children(); }
-
-// Row 2
-module R2U1() { _uhk80_key(2,1) children(); }
-module R2U1_25() { _uhk80_key(2,1.25) children(); }
-module R2U1_5() { _uhk80_key(2,1.5) children(); }
-module R2U1_75() { _uhk80_key(2,1.75) children(); }
-module R2U2() { _uhk80_key(2,2) children(); }
-module R2U2_25() { _uhk80_key(2,2.25) children(); }
-module R2U2_75() { _uhk80_key(2,2.75) children(); }
-module R2U6_25() { _uhk80_key(2,6.25) children(); }
-
-// Row 3
-module R3U1() { _uhk80_key(3,1) children(); }
-module R3U1_25() { _uhk80_key(3,1.25) children(); }
-module R3U1_5() { _uhk80_key(3,1.5) children(); }
-module R3U1_75() { _uhk80_key(3,1.75) children(); }
-module R3U2() { _uhk80_key(3,2) children(); }
-module R3U2_25() { _uhk80_key(3,2.25) children(); }
-module R3U2_75() { _uhk80_key(3,2.75) children(); }
-module R3U6_25() { _uhk80_key(3,6.25) children(); }
-
-// Row 4
-module R4U1() { _uhk80_key(4,1) children(); }
-module R4U1_25() { _uhk80_key(4,1.25) children(); }
-module R4U1_5() { _uhk80_key(4,1.5) children(); }
-module R4U1_75() { _uhk80_key(4,1.75) children(); }
-module R4U2() { _uhk80_key(4,2) children(); }
-module R4U2_25() { _uhk80_key(4,2.25) children(); }
-module R4U2_75() { _uhk80_key(4,2.75) children(); }
-module R4U6_25() { _uhk80_key(4,6.25) children(); }
-
-// Row 4X / 5 (bottom row)
-module R4XU1() { _uhk80_key(5,1) children(); }
-module R4XU1_25() { _uhk80_key(5,1.25) children(); }
-module R4XU1_5() { _uhk80_key(5,1.5) children(); }
-module R4XU1_75() { _uhk80_key(5,1.75) children(); }
-module R4XU2() { _uhk80_key(5,2) children(); }
-module R4XU2_25() { _uhk80_key(5,2.25) children(); }
-module R4XU2_75() { _uhk80_key(5,2.75) children(); }
-module R4XU6_25() { _uhk80_key(5,6.25) children(); }
-
-// Optional aliases for R5 naming
-module R5U1() { _uhk80_key(5,1) children(); }
-module R5U1_25() { _uhk80_key(5,1.25) children(); }
-module R5U1_5() { _uhk80_key(5,1.5) children(); }
-module R5U1_75() { _uhk80_key(5,1.75) children(); }
-module R5U2() { _uhk80_key(5,2) children(); }
-module R5U2_25() { _uhk80_key(5,2.25) children(); }
-module R5U2_75() { _uhk80_key(5,2.75) children(); }
-module R5U6_25() { _uhk80_key(5,6.25) children(); }
-
-// Layout data for UHK80 halves
-// Row numbers start at the top: row 1 is the F1/F7 row for left/right halves
-
-// Left half rows: [ [row, width, legend, (optional) font size], ... ]
-uhk80_left_rows = [
-  // Row 1
-  [
-    [1, 1, "Esc"],
-    [1, 1, "F1", 3],
-    [1, 1, "F2", 3],
-    [1, 1, "F3", 3],
-    [1, 1, "F4", 3],
-    [1, 1, "F5", 3],
-    [1, 1, "F6", 3]
-  ],
-  // Row 2
-  [
-    [2, 1, "1"], [2, 1, "2"], [2, 1, "3"],
-    [2, 1, "4"], [2, 1, "5"], [2, 1, "6"]
-  ],
-  // Row 3
-  [
-    [3, 1.5, "Tab"], [3, 1, "Q"], [3, 1, "W"],
-    [3, 1, "E"], [3, 1, "R"], [3, 1, "T"]
-  ],
-  // Row 4
-  [
-    [4, 1.75, "Caps"], [4, 1, "A"], [4, 1, "S"],
-    [4, 1, "D"], [4, 1, "F"], [4, 1, "G"]
-  ],
-  // Row 5
-  [
-    [5, 1.25, "Shift"], [5, 1, "Z"], [5, 1, "X"],
-    [5, 1, "C"], [5, 1, "V"], [5, 1, "B"]
-  ],
-  // Row 6 (bottom)
-  [
-    [5, 1.25, "Ctrl"], [5, 1.25, "Super"],
-    [5, 1.25, "Alt"], [5, 2.25, "Space"]
-  ]
-];
-
-// Right half rows
+// -----------------------------------------------------------------------------
+//  Layout data for the right half of the Ultimate Hacking Keyboard 80 (UHK80)
+// -----------------------------------------------------------------------------
+// Each element in `uhk80_right_rows` represents a row starting from the top.
+// Each row is an array of keys.  A key is represented by:
+//   [row_profile, width_in_u, legend_text, optional_font_size]
+// `row_profile` follows standard keyboard row numbering (1 = top row).
+// A `row_profile` of 0 marks an empty slot / spacer that advances the x offset
+// without rendering an actual key.
 uhk80_right_rows = [
-  // Row 1
+  // Row 1: function keys, print-screen cluster
   [
     [1, 1, "F7", 3], [1, 1, "F8", 3], [1, 1, "F9", 3],
     [1, 1, "F10", 3], [1, 1, "F11", 3], [1, 1, "F12", 3],
-    [0, 1.5],
+    [0, 1.5], // spacer between F-keys and print-screen cluster
     [1, 1.5, "PrtSc", 3], [1, 1, "Scroll", 3], [1, 1, "Pause", 3]
   ],
-  // Row 2
+
+  // Row 2: number row
   [
     [2, 1, "7"], [2, 1, "8"], [2, 1, "9"],
     [2, 1, "0"], [2, 1, "-"], [2, 1, "="],
     [1, 1.5, "Backspace"], [0, 0.5],
     [1, 1, "Insert"], [1, 1, "Home"], [1, 1, "PgUp"]
   ],
-  // Row 3
+
+  // Row 3: QWERTY row
   [
     [3, 1, "Y"], [3, 1, "U"], [3, 1, "I"],
     [3, 1, "O"], [3, 1, "P"], [3, 1, "["],
     [3, 1, "]"], [3, 1, "\\"],
     [2, 1, "Delete"], [2, 1, "End"], [2, 1, "PgDn"]
   ],
-  // Row 4
+
+  // Row 4: home row
   [
     [4, 1, "H"], [4, 1, "J"], [4, 1, "K"],
     [4, 1, "L"], [4, 1, ";"], [4, 1, "'"],
     [4, 2.25, "Enter"], [0, 0.75],
     [4, 1, "\u2190"], [4, 1, "\u2193"], [4, 1, "\u2192"]
   ],
-  // Row 5
+
+  // Row 5: bottom letter row
   [
     [5, 1, "N"], [5, 1, "M"], [5, 1, ","],
     [5, 1, "."], [5, 1, "/"], [5, 2.75, "Shift"]
   ],
-  // Row 6 (bottom)
+
+  // Row 6: space bar row
   [
     [5, 2.25, "Space"], [5, 1.25, "Alt"],
     [5, 1.25, "Fn"], [5, 1.25, "Ctrl"]
   ]
 ];
 
-// Render a single row from the right half of the layout.
-// row: row number starting at the top (1 = F7 row)
-// offset: horizontal shift applied before placing the first key
-module uhk80_right_row(row = 1, offset = 0) {
-  row_data = uhk80_right_rows[row - 1];
-  _uhk80_render_right_row(row_data, row, offset);
-}
 
-// Recursively render each key in a right-half row without mutating state.
-module _uhk80_render_right_row(row_data, row, x) {
-  if (len(row_data) > 0) {
-    key = row_data[0];
-    width = key[1];
-    if (len(key) > 2)
-      translate_u(x, -(row - 1))
-        _uhk80_key(key[0], width)
-          legend(key[2], size = len(key) > 3 ? key[3] : 4) key();
-    _uhk80_render_right_row(row_data[1:len(row_data)-1], row, x + width);
+// -----------------------------------------------------------------------------
+//  Render a single row from the right half
+// -----------------------------------------------------------------------------
+// row : 1-indexed row number counting from the top (1 = F7 row)
+// Example usage:
+//   use <uhk80.scad>
+//   uhk80_right_row(1);  // renders the top row on the right half
+module uhk80_right_row(row = 1) {
+
+  // Grab the key data for the requested row
+  row_data = uhk80_right_rows[row - 1];
+
+  // Track how far we've moved along the X axis.  Starts at 0 for the first key.
+  x_offset = 0;
+
+  // Loop over every key definition in the row
+  for (key = row_data) {
+
+    // Unpack the key definition for readability
+    row_profile = key[0];      // Which sculpted row this key uses (1..5). 0 = spacer.
+    width       = key[1];      // Width in "U" units (1u, 1.5u, etc)
+
+    // Only render real keys (skip spacers with row_profile == 0)
+    if (row_profile > 0) {
+
+      // Extract legend information, falling back to sensible defaults
+      legend_text = (len(key) > 2) ? key[2] : "";
+      font_size   = (len(key) > 3) ? key[3] : 4;
+
+      // Position the key:
+      //   * x_offset is how far we've moved to the right so far
+      //   * -(row - 1) moves down one unit per row (row1 -> 0, row2 -> -1, ...)
+      translate_u(x_offset, -(row - 1)) {
+
+        // Apply the appropriate row profile and key width before drawing
+        dcs_row(row_profile) u(width) {
+
+          // Apply the legend then render the key geometry
+          legend(legend_text, size = font_size) {
+            key();
+          }
+        }
+      }
+    }
+
+    // Move the x_offset forward by this key's width so the next key
+    // is placed immediately to the right
+    x_offset = x_offset + width;
   }
 }
 
-// Example: render only row 1 of the right half
-uhk80_right_row(1);
+// Uncomment the line below to preview the first row when this file is opened
+// uhk80_right_row(1);

--- a/uhk80.scad
+++ b/uhk80.scad
@@ -184,24 +184,31 @@ uhk80_right_rows = [
 module uhk80_half(side="both", rows=undef, gap=0.5) {
   if (side == "left" || side == "both")
     _uhk80_render_half(uhk80_left_rows, rows);
-  if (side == "right" || side == "both")
+  if (side == "right" || side == "both") {
+    right_end = side == "both"
+        ? 17
+        : max([for (row = uhk80_right_rows) sum([for (k = row) k[1]])]);
     translate_u(side == "both" ? gap : 0) {
       _uhk80_render_half(
         uhk80_right_rows,
         rows,
-        end_column=17,
+        end_column=right_end,
         align_right=true
       );
 
       // Arrow up key sits above the arrow cluster; render when row 3 is included
       if (rows == undef || rows == 3 || (is_list(rows) && len([for (r = rows) if (r == 3) r]) > 0))
-        translate_u(16, -2)
+        translate_u(right_end - 1, -2)
           _uhk80_key(3, 1) legend("\u2191") key();
     }
+  }
 }
 
 // Internal: render rows of keys using _uhk80_key
 module _uhk80_render_half(rows_data, rows=undef, end_column=undef, align_right=false, starts=0) {
+  end_col = align_right && end_column == undef
+      ? max([for (row = rows_data) sum([for (k = row) k[1]])])
+      : end_column;
   for (i = [0 : len(rows_data) - 1]) {
     row_number = i + 1;
     if (rows == undef || row_number == rows || (is_list(rows) && len([for (r = rows) if (r == row_number) r]) > 0)) {
@@ -213,9 +220,8 @@ module _uhk80_render_half(rows_data, rows=undef, end_column=undef, align_right=f
           ? (i < len(starts) ? starts[i] : 0)
           : starts;
       total_width = sum([for (k = row) k[1]]);
-      last_width = row[len(row) - 1][1];
-      x = align && end_column != undef
-          ? end_column - (total_width - last_width)
+      x = align && end_col != undef
+          ? end_col - total_width
           : start;
       for (key = row) {
         width = key[1];


### PR DESCRIPTION
## Summary
- allow selecting rows when rendering a UHK80 half
- compute key positions dynamically to align the right half's columns
- right half now aligns every row to the right and adds a small gap when both halves are rendered

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68abca01ad4c8320b8f1b9e323c9b027